### PR TITLE
Add the m-chromatic scale to 31EDO's list

### DIFF
--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -749,6 +749,7 @@ scaleDef scaleOptions[] = {
   { "Wyschnegradsky", TUNING_24EDO, { 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1 } },
   // 31 EDO; for more: https://en.xen.wiki/w/31edo#Scales
   { "Diatonic", TUNING_31EDO, { 5, 5, 3, 5, 5, 5, 3 } },
+  { "Chromatic", TUNING_31EDO, { 3, 2, 3, 2, 3, 2, 3, 3, 2, 3, 2, 3 } },
   { "Pentatonic", TUNING_31EDO, { 5, 5, 8, 5, 8 } },
   { "Harmonic", TUNING_31EDO, { 5, 5, 4, 4, 4, 3, 3, 3 } },
   { "Mavila", TUNING_31EDO, { 5, 3, 3, 3, 5, 3, 3, 3, 3 } },
@@ -758,6 +759,7 @@ scaleDef scaleOptions[] = {
   { "Miracle", TUNING_31EDO, { 4, 3, 3, 3, 3, 3, 3, 3, 3, 3 } },
   // 31 EDO ZETA PEAK;
   { "Diatonic", TUNING_31EDO_ZETA, { 5, 5, 3, 5, 5, 5, 3 } },
+  { "Chromatic", TUNING_31EDO_ZETA, { 3, 2, 3, 2, 3, 2, 3, 3, 2, 3, 2, 3 } },
   { "Pentatonic", TUNING_31EDO_ZETA, { 5, 5, 8, 5, 8 } },
   { "Harmonic", TUNING_31EDO_ZETA, { 5, 5, 4, 4, 4, 3, 3, 3 } },
   { "Mavila", TUNING_31EDO_ZETA, { 5, 3, 3, 3, 5, 3, 3, 3, 3 } },


### PR DESCRIPTION
The main way I've been trying to approach microtonalities is through Meantone[12].
All of our theory already applies; we've just got more usable keys.
I thought other people might find it useful as well if this scale was in the list.

Some more information about Meantone[12]:
---
* https://www.31edo.com/scales
* https://x31eq.com/meantone.htm

Rest of the commit message
---
This is the 7th rotation of 7L 5s (UDP 5|6).
It is one of the 6 supersets of the Ionian mode of the Diatonic scale that m-chromatic provides.
It is also the Meantone[12] tuning suggested on https://en.xen.wiki/w/Meantone_scales
Ideally this would go above the Diatonic definition in the code, but that would probably be too scary for newcomers.

The other superset modes are:
```
                5  5 3  5  5  5 3
6|5      2     Ls Ls L Ls Ls Ls L
5|6      7     Ls Ls L sL Ls Ls L
4|7     12     sL Ls L sL Ls Ls L
3|8      5     sL Ls L sL sL Ls L
2|9     10     sL sL L sL sL Ls L
1|10     3     sL sL L sL sL sL L
  ```