### PR TITLE
Disable user press key lighting in MIDI-IN animation mode

### DIFF
--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -1929,7 +1929,9 @@ void resetWheelLEDs() {
 uint32_t applyNotePixelColor(byte x) {
   if (h[x].animate) {
     return h[x].LEDcodeAnim;
-  } else if ((animationType != ANIMATE_NONE) && h[x].MIDIch) {
+  } else if ((animationType != ANIMATE_NONE)
+          && (animationType != ANIMATE_MIDI_IN)
+          && h[x].MIDIch) {
     return h[x].LEDcodePlay;
   } else if (h[x].inScale) {
     return h[x].LEDcodeRest;


### PR DESCRIPTION
Fix: Disable local key lighting in MIDI IN animation mode

Currently, when Animation is set to MIDI IN, locally pressed keys still light up,
which overlaps visually with incoming MIDI note visualization.

This change disables LEDcodePlay for locally pressed keys only when
animationType == ANIMATE_MIDI_IN, while preserving behavior for all other modes.

External MIDI visualization (h[x].animate) is unaffected.