### PR TITLE
Show key notes on display

### DIFF
--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -2820,9 +2820,13 @@ int16_t justIntonationRetune(byte x) {
 // --- Note display overlay when pressing keys ---
 constexpr byte DISPLAYED_NOTES_MAX = 6;
 constexpr int16_t DISPLAYED_NOTE_UNUSED = INT16_MIN;
+constexpr uint64_t DISPLAYED_NOTES_HOLD_MICROS = 2000000ULL;
+constexpr uint64_t DISPLAYED_NOTES_RELEASE_GRACE_MICROS = 80000ULL;
 bool displayPlayedNotes = false;
 bool noteOverlayVisible = false;
 bool noteOverlayDirty = true;
+uint64_t noteOverlayHoldUntil = 0;
+uint64_t noteOverlayReleaseGraceUntil = 0;
 int16_t displayedNotes[DISPLAYED_NOTES_MAX] = {
   DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED,
   DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED
@@ -2833,8 +2837,11 @@ const char* chromaticNames[12] = {
   "F#", "G", "G#", "A", "Bb", "B"
 };
 
-void rebuildDisplayedNotes();
-byte displayedNoteCount();
+void clearDisplayedNotes(int16_t* notes);
+void copyDisplayedNotes(int16_t* destination, const int16_t* source);
+byte rebuildDisplayedNotes(int16_t* notes);
+byte displayedNoteCount(const int16_t* notes);
+bool displayedNotesEqual(const int16_t* first, const int16_t* second);
 void drawPlayedNotesOverlay();
 void onToggleDisplayPlayedNotes();
 /* NEW */
@@ -2901,6 +2908,7 @@ void tryMIDInoteOn(byte x) {
       }
       // Then, send the note-on message
       withMIDI([&](auto& M) { M.sendNoteOn(h[x].note, velWheel.curValue, h[x].MIDIch); });  // ch 1-16
+      noteOverlayReleaseGraceUntil = 0;
       noteOverlayDirty = true;
 
       sendToLog(
@@ -2930,6 +2938,7 @@ void tryMIDInoteOff(byte x) {
       }
       releaseMPEChannel(h[x].MIDIch);
     }
+    noteOverlayReleaseGraceUntil = runTime + DISPLAYED_NOTES_RELEASE_GRACE_MICROS;
     noteOverlayDirty = true;
     h[x].MIDIch = 0;
   }
@@ -5077,11 +5086,20 @@ uint64_t screenTime = 0;                         // GFX timer to count if screen
 const uint64_t screenSaverTimeout = (1u << 25);  // 2^25 microseconds ~ 33 seconds
 
 // Updates notes on display when keys are pressed
-void rebuildDisplayedNotes() {
+void clearDisplayedNotes(int16_t* notes) {
   for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
-    displayedNotes[i] = DISPLAYED_NOTE_UNUSED;
+    notes[i] = DISPLAYED_NOTE_UNUSED;
   }
+}
 
+void copyDisplayedNotes(int16_t* destination, const int16_t* source) {
+  for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
+    destination[i] = source[i];
+  }
+}
+
+byte rebuildDisplayedNotes(int16_t* notes) {
+  clearDisplayedNotes(notes);
   byte out = 0;
   for (byte i = 0; i < LED_COUNT && out < DISPLAYED_NOTES_MAX; i++) {
     if (h[i].isCmd) {
@@ -5095,32 +5113,45 @@ void rebuildDisplayedNotes() {
 
     bool alreadyListed = false;
     for (byte j = 0; j < out; j++) {
-      if (displayedNotes[j] == displayedPitch) {
+      if (notes[j] == displayedPitch) {
         alreadyListed = true;
         break;
       }
     }
 
     if (!alreadyListed) {
-      displayedNotes[out++] = displayedPitch;
+      notes[out++] = displayedPitch;
     }
   }
+  return out;
 }
 
-byte displayedNoteCount() {
+byte displayedNoteCount(const int16_t* notes) {
   byte count = 0;
   for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
-    if (displayedNotes[i] != DISPLAYED_NOTE_UNUSED) {
+    if (notes[i] != DISPLAYED_NOTE_UNUSED) {
       count++;
     }
   }
   return count;
 }
 
+bool displayedNotesEqual(const int16_t* first, const int16_t* second) {
+  for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
+    if (first[i] != second[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void onToggleDisplayPlayedNotes() {
   if (!displayPlayedNotes && noteOverlayVisible) {
     noteOverlayVisible = false;
     noteOverlayDirty = false;
+    noteOverlayHoldUntil = 0;
+    noteOverlayReleaseGraceUntil = 0;
+    clearDisplayedNotes(displayedNotes);
     menu.drawMenu();
   } else if (displayPlayedNotes) {
     noteOverlayDirty = true;
@@ -5136,10 +5167,35 @@ void drawPlayedNotesOverlay() {
     return;
   }
 
-  rebuildDisplayedNotes();
-  byte count = displayedNoteCount();
+  int16_t activeDisplayedNotes[DISPLAYED_NOTES_MAX];
+  byte activeCount = rebuildDisplayedNotes(activeDisplayedNotes);
+  byte countBefore = displayedNoteCount(displayedNotes);
+  bool snapshotChanged = false;
 
-  if (count == 0) {
+  if (activeCount > 0) {
+    bool notesChanged = !displayedNotesEqual(displayedNotes, activeDisplayedNotes);
+    bool shouldDelayChordShrink = notesChanged &&
+                                  activeCount < countBefore &&
+                                  countBefore > 0 &&
+                                  runTime <= noteOverlayReleaseGraceUntil;
+
+    if (!shouldDelayChordShrink && notesChanged) {
+      copyDisplayedNotes(displayedNotes, activeDisplayedNotes);
+      snapshotChanged = true;
+    }
+
+    noteOverlayHoldUntil = runTime + DISPLAYED_NOTES_HOLD_MICROS;
+    if (!shouldDelayChordShrink) {
+      noteOverlayReleaseGraceUntil = 0;
+    }
+  }
+
+  byte count = displayedNoteCount(displayedNotes);
+
+  if (activeCount == 0 && (count == 0 || runTime > noteOverlayHoldUntil)) {
+    noteOverlayHoldUntil = 0;
+    noteOverlayReleaseGraceUntil = 0;
+    clearDisplayedNotes(displayedNotes);
     if (noteOverlayVisible) {
       noteOverlayVisible = false;
       noteOverlayDirty = false;
@@ -5148,7 +5204,7 @@ void drawPlayedNotesOverlay() {
     return;
   }
 
-  if (!noteOverlayDirty && noteOverlayVisible) {
+  if (!noteOverlayDirty && noteOverlayVisible && !snapshotChanged) {
     return;
   }
 

--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -2846,14 +2846,15 @@ extern U8G2_SH1107_SEEED_128X128_F_HW_I2C u8g2;
 #endif
 
 void tryMIDInoteOn(byte x) {
-  // This section to wake the screen when notes are pressed for displaying the notes on the screen
-  screenTime = 0;
-  if (screenSaverOn) {
-    screenSaverOn = 0;
-    u8g2.setContrast(CONTRAST_AWAKE);
-    noteOverlayDirty = true;
+  // Only wake/reset the screen timer when note display is enabled.
+  if (displayPlayedNotes) {
+    screenTime = 0;
+      if (screenSaverOn) {
+        screenSaverOn = 0;
+        u8g2.setContrast(CONTRAST_AWAKE);
+        noteOverlayDirty = true;   
+      }
   }
-
   // This gets called on any non-command hex that is not scale-locked.
   if (h[x].note >= 128) {
     return;

--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -2819,12 +2819,13 @@ int16_t justIntonationRetune(byte x) {
 
 // --- Note display overlay when pressing keys ---
 constexpr byte DISPLAYED_NOTES_MAX = 6;
+constexpr int16_t DISPLAYED_NOTE_UNUSED = INT16_MIN;
 bool displayPlayedNotes = false;
 bool noteOverlayVisible = false;
 bool noteOverlayDirty = true;
-byte displayedNotes[DISPLAYED_NOTES_MAX] = {
-  UNUSED_NOTE, UNUSED_NOTE, UNUSED_NOTE,
-  UNUSED_NOTE, UNUSED_NOTE, UNUSED_NOTE
+int16_t displayedNotes[DISPLAYED_NOTES_MAX] = {
+  DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED,
+  DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED, DISPLAYED_NOTE_UNUSED
 };
 
 const char* chromaticNames[12] = {
@@ -5078,7 +5079,7 @@ const uint64_t screenSaverTimeout = (1u << 25);  // 2^25 microseconds ~ 33 secon
 // Updates notes on display when keys are pressed
 void rebuildDisplayedNotes() {
   for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
-    displayedNotes[i] = UNUSED_NOTE;
+    displayedNotes[i] = DISPLAYED_NOTE_UNUSED;
   }
 
   byte out = 0;
@@ -5089,20 +5090,19 @@ void rebuildDisplayedNotes() {
     if (h[i].MIDIch == 0) {
       continue;
     }
-    if (h[i].note >= 128) {
-      continue;
-    }
+
+    int16_t displayedPitch = h[i].stepsFromC + current.transpose;
 
     bool alreadyListed = false;
     for (byte j = 0; j < out; j++) {
-      if (displayedNotes[j] == h[i].note) {
+      if (displayedNotes[j] == displayedPitch) {
         alreadyListed = true;
         break;
       }
     }
 
     if (!alreadyListed) {
-      displayedNotes[out++] = h[i].note;
+      displayedNotes[out++] = displayedPitch;
     }
   }
 }
@@ -5110,7 +5110,7 @@ void rebuildDisplayedNotes() {
 byte displayedNoteCount() {
   byte count = 0;
   for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
-    if (displayedNotes[i] != UNUSED_NOTE) {
+    if (displayedNotes[i] != DISPLAYED_NOTE_UNUSED) {
       count++;
     }
   }
@@ -5161,11 +5161,21 @@ void drawPlayedNotesOverlay() {
 
   // 3 columns x 2 rows = 6 notes max
   for (byte i = 0; i < count; i++) {
-    byte midiNote = displayedNotes[i];
-    const char* label = chromaticNames[midiNote % 12];
-    int octave = (midiNote / 12) - 1;
-    char noteText[8];
-    snprintf(noteText, sizeof(noteText), "%s%d", label, octave);
+    int16_t displayedPitch = displayedNotes[i];
+    char noteText[12];
+
+    if (current.tuningIndex == TUNING_12EDO) {
+      int midiNote = displayedPitch + 60;
+      const char* label = chromaticNames[positiveMod(midiNote, 12)];
+      int octave = (midiNote / 12) - 1;
+      snprintf(noteText, sizeof(noteText), "%s%d", label, octave);
+    } else {
+      int cycleLength = current.tuning().cycleLength;
+      int step = positiveMod(displayedPitch, cycleLength);
+      int octave = ((displayedPitch - step) / cycleLength) + 4;
+      snprintf(noteText, sizeof(noteText), "%d.%d", step, octave);
+    }
+
     byte col = i % 3;
     byte row = i / 3;
     int x = (col == 0) ? 2 : (col == 1) ? 42 : 82;

--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -2817,7 +2817,43 @@ int16_t justIntonationRetune(byte x) {
 }
 
 
+// --- Note display overlay when pressing keys ---
+constexpr byte DISPLAYED_NOTES_MAX = 6;
+bool displayPlayedNotes = false;
+bool noteOverlayVisible = false;
+bool noteOverlayDirty = true;
+byte displayedNotes[DISPLAYED_NOTES_MAX] = {
+  UNUSED_NOTE, UNUSED_NOTE, UNUSED_NOTE,
+  UNUSED_NOTE, UNUSED_NOTE, UNUSED_NOTE
+};
+
+const char* chromaticNames[12] = {
+  "C", "C#", "D", "Eb", "E", "F",
+  "F#", "G", "G#", "A", "Bb", "B"
+};
+
+void rebuildDisplayedNotes();
+byte displayedNoteCount();
+void drawPlayedNotesOverlay();
+void onToggleDisplayPlayedNotes();
+/* NEW */
+extern uint64_t screenTime;
+extern bool screenSaverOn;
+extern U8G2_SH1107_SEEED_128X128_F_HW_I2C u8g2;
+
+#ifndef CONTRAST_AWAKE
+#define CONTRAST_AWAKE 63
+#endif
+
 void tryMIDInoteOn(byte x) {
+  // This section to wake the screen when notes are pressed for displaying the notes on the screen
+  screenTime = 0;
+  if (screenSaverOn) {
+    screenSaverOn = 0;
+    u8g2.setContrast(CONTRAST_AWAKE);
+    noteOverlayDirty = true;
+  }
+
   // This gets called on any non-command hex that is not scale-locked.
   if (h[x].note >= 128) {
     return;
@@ -2863,6 +2899,7 @@ void tryMIDInoteOn(byte x) {
       }
       // Then, send the note-on message
       withMIDI([&](auto& M) { M.sendNoteOn(h[x].note, velWheel.curValue, h[x].MIDIch); });  // ch 1-16
+      noteOverlayDirty = true;
 
       sendToLog(
         "Sent MIDI pitch bend: " + std::to_string(pitchBendValue) + " to ch " + std::to_string(h[x].MIDIch));
@@ -2891,6 +2928,7 @@ void tryMIDInoteOff(byte x) {
       }
       releaseMPEChannel(h[x].MIDIch);
     }
+    noteOverlayDirty = true;
     h[x].MIDIch = 0;
   }
 }
@@ -4043,7 +4081,7 @@ void RAM_FUNC(retryPendingReleases)() {
       --releaseRetryCountdown[i];
       continue;
     }
-    publishEnvelopeCommand(i, EnvelopeCommand::StartRelease);
+	publishEnvelopeCommand(i, EnvelopeCommand::StartRelease);
     releaseRetryCountdown[i] = releaseRetryDelayLoops;
     releaseRetries[i] = static_cast<uint8_t>(retries - 1);
   }
@@ -4747,6 +4785,7 @@ enum class SettingKey : uint8_t {
   EnvelopeSustainLevel,
   EnvelopeReleaseIndex,
   Delegated,
+  DisplayPlayedNotes,
   // This must remain last – it gives the total number of settings.
   NumSettings
 };
@@ -4814,6 +4853,8 @@ const uint8_t factoryDefaults[NUM_SETTINGS] = {
   /* EnvelopeDecayIndex           */ 3,
   /* EnvelopeSustainLevel         */ 127,
   /* EnvelopeReleaseIndex         */ 3,
+  /* Delegated                    */ 0,
+  /* Display played notes         */ 0,
 };
 
 // ==================================================
@@ -5032,6 +5073,110 @@ bool screenSaverOn = 0;
 bool audioMenuItemInserted = false;
 uint64_t screenTime = 0;                         // GFX timer to count if screensaver should go on
 const uint64_t screenSaverTimeout = (1u << 25);  // 2^25 microseconds ~ 33 seconds
+
+// Updates notes on display when keys are pressed
+void rebuildDisplayedNotes() {
+  for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
+    displayedNotes[i] = UNUSED_NOTE;
+  }
+
+  byte out = 0;
+  for (byte i = 0; i < LED_COUNT && out < DISPLAYED_NOTES_MAX; i++) {
+    if (h[i].isCmd) {
+      continue;
+    }
+    if (h[i].MIDIch == 0) {
+      continue;
+    }
+    if (h[i].note >= 128) {
+      continue;
+    }
+
+    bool alreadyListed = false;
+    for (byte j = 0; j < out; j++) {
+      if (displayedNotes[j] == h[i].note) {
+        alreadyListed = true;
+        break;
+      }
+    }
+
+    if (!alreadyListed) {
+      displayedNotes[out++] = h[i].note;
+    }
+  }
+}
+
+byte displayedNoteCount() {
+  byte count = 0;
+  for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
+    if (displayedNotes[i] != UNUSED_NOTE) {
+      count++;
+    }
+  }
+  return count;
+}
+
+void onToggleDisplayPlayedNotes() {
+  if (!displayPlayedNotes && noteOverlayVisible) {
+    noteOverlayVisible = false;
+    noteOverlayDirty = false;
+    menu.drawMenu();
+  } else if (displayPlayedNotes) {
+    noteOverlayDirty = true;
+  }
+}
+
+void drawPlayedNotesOverlay() {
+  if (!displayPlayedNotes) {
+    return;
+  }
+
+  if (screenSaverOn) {
+    return;
+  }
+
+  rebuildDisplayedNotes();
+  byte count = displayedNoteCount();
+
+  if (count == 0) {
+    if (noteOverlayVisible) {
+      noteOverlayVisible = false;
+      noteOverlayDirty = false;
+      menu.drawMenu();
+    }
+    return;
+  }
+
+  if (!noteOverlayDirty && noteOverlayVisible) {
+    return;
+  }
+
+  noteOverlayVisible = true;
+  noteOverlayDirty = false;
+
+  u8g2.clearBuffer();
+  u8g2.setFont(u8g2_font_6x13_tf);
+  u8g2.drawStr(8, 16, "Now Playing");
+
+  // 3 columns x 2 rows = 6 notes max
+  for (byte i = 0; i < count; i++) {
+    byte midiNote = displayedNotes[i];
+    const char* label = chromaticNames[midiNote % 12];
+    int octave = (midiNote / 12) - 1;
+    char noteText[8];
+    snprintf(noteText, sizeof(noteText), "%s%d", label, octave);
+    byte col = i % 3;
+    byte row = i / 3;
+    int x = (col == 0) ? 2 : (col == 1) ? 42 : 82;
+    int y = 34 + (row * 26);
+
+    u8g2.setFont(u8g2_font_logisoso16_tf);
+    u8g2.drawStr(x, y, noteText);
+  }
+
+  u8g2.sendBuffer();
+}
+
 /*
     Create menu page object of class GEMPage.
     Menu page holds menu items (GEMItem) and represents menu level.
@@ -5309,6 +5454,13 @@ PersistentCallbackInfo callbackInfoDebug = {
 };
 GEMItem menuItemDebug("Serial Debug", debugMessages, universalSaveCallback, reinterpret_cast<void*>(&callbackInfoDebug));
 
+PersistentCallbackInfo callbackInfoDisplayPlayedNotes = {
+  static_cast<uint8_t>(SettingKey::DisplayPlayedNotes),
+  reinterpret_cast<void*>(&displayPlayedNotes),
+  nullptr,
+  onToggleDisplayPlayedNotes
+};
+GEMItem menuItemDisplayPlayedNotes("DisplayNotes", displayPlayedNotes, universalSaveCallback, reinterpret_cast<void*>(&callbackInfoDisplayPlayedNotes));
 
 
 SelectOptionByte optionByteWheelType[] = { { "Springy", 0 }, { "Sticky", 1 } };
@@ -6421,6 +6573,7 @@ void syncSettingsToRuntime() {
   envelopeDecayIndex = settings[static_cast<uint8_t>(SettingKey::EnvelopeDecayIndex)];
   envelopeSustainLevel = settings[static_cast<uint8_t>(SettingKey::EnvelopeSustainLevel)];
   envelopeReleaseIndex = settings[static_cast<uint8_t>(SettingKey::EnvelopeReleaseIndex)];
+  displayPlayedNotes = (settings[static_cast<uint8_t>(SettingKey::DisplayPlayedNotes)] !=0);
   updateEnvelopeParamsFromSettings();
   updateArpeggiatorTiming();
 
@@ -6753,6 +6906,7 @@ void setupMenu() {
   menuPageAdvanced.addMenuItem(menuItemHardware);
   menuPageAdvanced.addMenuItem(menuItemRotary);
   menuPageAdvanced.addMenuItem(menuItemShiftColor);
+  menuPageAdvanced.addMenuItem(menuItemDisplayPlayedNotes);
   // menuPageAdvanced.addMenuItem(menuItemWheelAlt); // not sure why we have this, so I'm hiding it for now
   menuPageAdvanced.addMenuItem(menuItemResetDefaults);
   menuPageAdvanced.addMenuItem(menuItemUSBBootloader);
@@ -7058,6 +7212,7 @@ void loop() {        // run on first core
   animateLEDs();     // deal with animations
   lightUpLEDs();     // refresh LEDs
   dealWithRotary();  // deal with menu
+  drawPlayedNotesOverlay(); // shows the notes of keys pressed on the screen
   checkAndAutoSave();// save settings
 }
 void setup1() {  // set up on second core

--- a/src/HexBoard.ino
+++ b/src/HexBoard.ino
@@ -2825,6 +2825,8 @@ constexpr uint64_t DISPLAYED_NOTES_RELEASE_GRACE_MICROS = 80000ULL;
 bool displayPlayedNotes = false;
 bool noteOverlayVisible = false;
 bool noteOverlayDirty = true;
+bool noteOverlayTemporaryWake = false;
+bool noteOverlayWokeDisplayFromSleep = false;
 uint64_t noteOverlayHoldUntil = 0;
 uint64_t noteOverlayReleaseGraceUntil = 0;
 int16_t displayedNotes[DISPLAYED_NOTES_MAX] = {
@@ -2844,6 +2846,7 @@ byte displayedNoteCount(const int16_t* notes);
 bool displayedNotesEqual(const int16_t* first, const int16_t* second);
 void drawPlayedNotesOverlay();
 void onToggleDisplayPlayedNotes();
+bool setNoteOverlayTemporaryWake(bool enabled);
 /* NEW */
 extern uint64_t screenTime;
 extern bool screenSaverOn;
@@ -2854,14 +2857,9 @@ extern U8G2_SH1107_SEEED_128X128_F_HW_I2C u8g2;
 #endif
 
 void tryMIDInoteOn(byte x) {
-  // Only wake/reset the screen timer when note display is enabled.
-  if (displayPlayedNotes) {
-    screenTime = 0;
-      if (screenSaverOn) {
-        screenSaverOn = 0;
-        u8g2.setContrast(CONTRAST_AWAKE);
-        noteOverlayDirty = true;   
-      }
+  if (displayPlayedNotes && screenSaverOn) {
+    setNoteOverlayTemporaryWake(true);
+    noteOverlayDirty = true;
   }
   // This gets called on any non-command hex that is not scale-locked.
   if (h[x].note >= 128) {
@@ -5085,6 +5083,27 @@ bool audioMenuItemInserted = false;
 uint64_t screenTime = 0;                         // GFX timer to count if screensaver should go on
 const uint64_t screenSaverTimeout = (1u << 25);  // 2^25 microseconds ~ 33 seconds
 
+bool setNoteOverlayTemporaryWake(bool enabled) {
+  noteOverlayTemporaryWake = enabled;
+  if (enabled) {
+    noteOverlayWokeDisplayFromSleep = screenSaverOn;
+    if (screenSaverOn) {
+      screenSaverOn = 0;
+      u8g2.setContrast(CONTRAST_AWAKE);
+    }
+    return false;
+  }
+
+  bool returnedToSleep = noteOverlayWokeDisplayFromSleep && screenTime > screenSaverTimeout;
+  if (returnedToSleep && !screenSaverOn) {
+    screenSaverOn = 1;
+    u8g2.setContrast(CONTRAST_SCREENSAVER);
+    u8g2.clear();
+  }
+  noteOverlayWokeDisplayFromSleep = false;
+  return returnedToSleep;
+}
+
 // Updates notes on display when keys are pressed
 void clearDisplayedNotes(int16_t* notes) {
   for (byte i = 0; i < DISPLAYED_NOTES_MAX; i++) {
@@ -5149,10 +5168,13 @@ void onToggleDisplayPlayedNotes() {
   if (!displayPlayedNotes && noteOverlayVisible) {
     noteOverlayVisible = false;
     noteOverlayDirty = false;
+    bool returnedToSleep = setNoteOverlayTemporaryWake(false);
     noteOverlayHoldUntil = 0;
     noteOverlayReleaseGraceUntil = 0;
     clearDisplayedNotes(displayedNotes);
-    menu.drawMenu();
+    if (!returnedToSleep) {
+      menu.drawMenu();
+    }
   } else if (displayPlayedNotes) {
     noteOverlayDirty = true;
   }
@@ -5163,7 +5185,7 @@ void drawPlayedNotesOverlay() {
     return;
   }
 
-  if (screenSaverOn) {
+  if (screenSaverOn && !noteOverlayTemporaryWake) {
     return;
   }
 
@@ -5193,13 +5215,16 @@ void drawPlayedNotesOverlay() {
   byte count = displayedNoteCount(displayedNotes);
 
   if (activeCount == 0 && (count == 0 || runTime > noteOverlayHoldUntil)) {
+    bool returnedToSleep = setNoteOverlayTemporaryWake(false);
     noteOverlayHoldUntil = 0;
     noteOverlayReleaseGraceUntil = 0;
     clearDisplayedNotes(displayedNotes);
     if (noteOverlayVisible) {
       noteOverlayVisible = false;
       noteOverlayDirty = false;
-      menu.drawMenu();
+      if (!returnedToSleep) {
+        menu.drawMenu();
+      }
     }
     return;
   }
@@ -6987,6 +7012,14 @@ void setupGFX() {
   sendToLog("U8G2 graphics initialized.");
 }
 void screenSaver() {
+  if (noteOverlayTemporaryWake) {
+    if (screenSaverOn) {
+      screenSaverOn = 0;
+      u8g2.setContrast(CONTRAST_AWAKE);
+    }
+    return;
+  }
+
   if (screenTime <= screenSaverTimeout) {
     screenTime = screenTime + lapTime;
     if (screenSaverOn) {


### PR DESCRIPTION
Show notes on display, up to 6 keys at once only as long as the key is pressed plus two extra seconds when let go unless user presses new keys after that then it's replaced with a new note display. Must turn on under Advanced > DisplayNotes. Defaults to off. Notes are displayed in order pressed with the oldest pushed back, so the newest note is always the first note. I made more advanced versions, but prefer a simple one like this. Perfect if you just need a reminder what note specific keys are.

Microtonal also works now.

Besides displaying the notes when on it should also:
When pressing a note when display is sleeping it should wake it just long enough to display it for the time held plus the two extra seconds.
If note display is off the display stays asleep.
