### PR TITLE
Add physical menu shortcut buttons

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -365,6 +365,10 @@ step every two command-message cooldown windows. Positive values keep the old
 one-step-per-cooldown behavior, so existing profile bytes remain meaningful
 after the user-facing speed names shifted.
 
+`GridScanRotary.cpp` intercepts the bottom-command-button menu shortcut before
+normal command-button behavior and masks those shortcut buttons during wheel
+updates so menu navigation does not also move velocity, modulation, or pitch bend.
+
 If you repurpose command buttons:
 
 - update the `CMDBTN_*` mapping

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -69,6 +69,11 @@ The wheel behavior depends on menu settings:
 - `Springy`: returns to its default value when released
 - `Sticky`: holds its last value
 
+When the OLED menu or a list browser is active, hold the bottom command button
+as a modifier and press the top two command buttons to navigate: top moves up,
+middle moves down. While editing a menu value, top increases the value and
+middle decreases it.
+
 ### Rotary Encoder
 
 The encoder controls the OLED menu:

--- a/src/firmware/hardware/GridScanRotary.cpp
+++ b/src/firmware/hardware/GridScanRotary.cpp
@@ -59,6 +59,48 @@ uint64_t rotaryPressStart = 0;
 bool rotaryPanicLatched = false;
 bool rotaryPanicSuppressClick = false;
 
+static bool RAM_FUNC(menuShortcutButtonsEnabled)() {
+  if (delegatedControl || stabilityBenchmarkIsActive()) {
+    return false;
+  }
+  byte modifierState = h[assignCmd[6]].btnState;
+  bool modifierHeld = (modifierState == BTN_STATE_NEWPRESS || modifierState == BTN_STATE_HELD);
+  return modifierHeld && (virtualListMenuIsActive() || menu.readyForKey());
+}
+
+static bool RAM_FUNC(menuShortcutUsesValueDirection)() {
+  return menu.isEditMode();
+}
+
+static byte RAM_FUNC(menuShortcutMenuKey)(bool isTopShortcutButton) {
+  if (menuShortcutUsesValueDirection()) {
+    return isTopShortcutButton ? GEM_KEY_DOWN : GEM_KEY_UP;
+  }
+  return isTopShortcutButton ? GEM_KEY_UP : GEM_KEY_DOWN;
+}
+
+static bool RAM_FUNC(handleMenuShortcutButton)(byte buttonIndex, bool pressed) {
+  if (buttonIndex != assignCmd[0] && buttonIndex != assignCmd[1]) {
+    return false;
+  }
+  if (!menuShortcutButtonsEnabled()) {
+    return false;
+  }
+
+  if (pressed) {
+    dismissPlayedNotesOverlayForMenuInput();
+    byte keyCode = menuShortcutMenuKey(buttonIndex == assignCmd[0]);
+    if (virtualListMenuIsActive()) {
+      handleVirtualListMenuKey(keyCode);
+    } else {
+      menu.registerKeyPress(keyCode);
+    }
+    noteOverlayDirty = true;
+    screenTime = 0;
+  }
+  return true;
+}
+
 void RAM_FUNC(readHexes)() {
 
   // Optimized button reading using SIO registers - much faster!
@@ -83,6 +125,9 @@ void RAM_FUNC(readHexes)() {
   for (byte i = 0; i < BTN_COUNT; i++) {  // For all buttons in the deck
     switch (h[i].btnState) {
       case BTN_STATE_NEWPRESS:  // just pressed
+        if (handleMenuShortcutButton(i, true)) {
+          break;
+        }
         if (delegatedControl) {
           delegatedButtonEvent(i, true);
         } else if (h[i].isCmd) {
@@ -93,6 +138,9 @@ void RAM_FUNC(readHexes)() {
         }
         break;
       case BTN_STATE_RELEASED:  // just released
+        if (handleMenuShortcutButton(i, false)) {
+          break;
+        }
         if (delegatedControl) {
           delegatedButtonEvent(i, false);
         } else if (h[i].isCmd) {
@@ -113,6 +161,17 @@ void RAM_FUNC(updateWheels)() {
   if (delegatedControl) {
     return;
   }
+
+  bool menuShortcutButtonsActive = menuShortcutButtonsEnabled();
+  byte savedMenuShortcutTopState = h[assignCmd[0]].btnState;
+  byte savedMenuShortcutMidState = h[assignCmd[1]].btnState;
+  byte savedMenuShortcutModifierState = h[assignCmd[6]].btnState;
+  if (menuShortcutButtonsActive) {
+    h[assignCmd[0]].btnState = BTN_STATE_OFF;
+    h[assignCmd[1]].btnState = BTN_STATE_OFF;
+    h[assignCmd[6]].btnState = BTN_STATE_OFF;
+  }
+
   velWheel.setTargetValue();
   bool upd = velWheel.updateValue(runTime);
   if (upd) {
@@ -131,6 +190,12 @@ void RAM_FUNC(updateWheels)() {
     if (upd) {
       sendMIDImodulationToCh1();
     }
+  }
+
+  if (menuShortcutButtonsActive) {
+    h[assignCmd[0]].btnState = savedMenuShortcutTopState;
+    h[assignCmd[1]].btnState = savedMenuShortcutMidState;
+    h[assignCmd[6]].btnState = savedMenuShortcutModifierState;
   }
 }
 void setupRotary() {


### PR DESCRIPTION

Adds a physical menu-navigation shortcut using existing command buttons.

When the OLED menu or a virtual list browser is active, holding the bottom command button as a modifier lets the top two command buttons navigate the menu:

- top command button: move up
- middle command button: move down
- while editing a menu value, top increases and middle decreases

The shortcut is ignored during delegated control and stability benchmark mode. The implementation also masks the shortcut buttons during wheel updates so menu navigation does not also change velocity, modulation, or pitch bend.