### PR TITLE
Add command wheel OLED overlay

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -103,6 +103,7 @@ button matrix -> readHexes()
               -> tryMIDInoteOn/Off() -> USB/serial MIDI
               -> trySynthNoteOn/Off() -> envelope commands -> audio block renderer -> DMA -> PWM audio
               -> LED state -> lightUpLEDs()
+              -> command-wheel value updates -> drawCommandWheelOverlay()
               -> played-note snapshot -> drawPlayedNotesOverlay()
 
 rotary encoder -> readKnob() on core 1 -> dealWithRotary() on core 0 -> GEM menu
@@ -129,6 +130,14 @@ note/wheel sends, synth voice allocation, rotary quadrature polling, compact LED
 frame helpers, and small synth lookup tables read by the renderer. Avoid moving
 OLED/GEM/U8g2 drawing wholesale; those paths are dominated by library calls and
 I2C transfer time.
+
+The command-wheel OLED readout follows that split: the RAM-resident wheel path
+only records lightweight overlay state when a velocity, modulation, or
+pitch-bend value changes or a command-wheel gesture requests feedback, while the
+normal display phase renders the full screen with throttled redraws. Other OLED
+renderers dismiss the command-wheel readout before drawing so menu, list,
+Sequencer, played-note, delegated-control, save, and transfer screens always own
+the display they update.
 
 ## Source Map
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -80,10 +80,13 @@ The wheel behavior depends on menu settings:
 - `Springy`: returns to its default value when released
 - `Sticky`: holds its last value
 
-When the OLED menu or a list browser is active, hold the bottom command button
-as a modifier and press the top two command buttons to navigate: top moves up,
-middle moves down. While editing a menu value, top increases the value and
-middle decreases it.
+When a command-wheel value changes, the OLED briefly shows a full-screen
+readout with the control name, the current value, and a simple meter. Velocity
+and modulation show raw `0`-`127` values. Pitch bend shows a centered percentage
+from `-100%` to `+100%`. The readout updates while a held wheel button moves the
+value, and clears after about `3 seconds`, or sooner if another menu, list,
+Sequencer, played-note, delegated-control, save, or transfer screen updates the
+display.
 
 ### Rotary Encoder
 

--- a/src/firmware/app/Runtime.cpp
+++ b/src/firmware/app/Runtime.cpp
@@ -6,6 +6,7 @@
 #include "../hardware/GridState.h"
 #include "../hardware/LedAnimations.h"
 #include "../hardware/LedRender.h"
+#include "../menu/CommandWheelOverlay.h"
 #include "../menu/GeometryMenu.h"
 #include "../menu/MenuAndDisplay.h"
 #include "../menu/PlayedNotesOverlay.h"
@@ -131,6 +132,7 @@ void hexboardLoop() {        // run on first core
   if (sequencerModeActive()) {
     drawSequencerModeDisplay();
   }
+  drawCommandWheelOverlay();
   drawPlayedNotesOverlay(); // shows the notes of keys pressed on the screen
   stabilityBenchmarkSetCore0Task(STABILITY_TASK_BENCHMARK);
   serviceStabilityBenchmark();

--- a/src/firmware/hardware/GridScanRotary.cpp
+++ b/src/firmware/hardware/GridScanRotary.cpp
@@ -12,6 +12,7 @@
 #include "../midi/NoteDispatch.h"
 #include "../sequencer/SequencerMode.h"
 #include "GridScanRotary.h"
+#include "../menu/CommandWheelOverlay.h"
 #include "../menu/MenuAndDisplay.h"
 #include "../menu/PlayedNotesOverlay.h"
 #include "../menu/VirtualListMenu.h"
@@ -59,48 +60,9 @@ constexpr uint64_t ROTARY_PANIC_HOLD_MICROS = 2000000ULL;  // 2 seconds
 uint64_t rotaryPressStart = 0;
 bool rotaryPanicLatched = false;
 bool rotaryPanicSuppressClick = false;
-
-static bool RAM_FUNC(menuShortcutButtonsEnabled)() {
-  if (delegatedControl || stabilityBenchmarkIsActive()) {
-    return false;
-  }
-  byte modifierState = h[assignCmd[6]].btnState;
-  bool modifierHeld = (modifierState == BTN_STATE_NEWPRESS || modifierState == BTN_STATE_HELD);
-  return modifierHeld && (virtualListMenuIsActive() || menu.readyForKey());
-}
-
-static bool RAM_FUNC(menuShortcutUsesValueDirection)() {
-  return menu.isEditMode();
-}
-
-static byte RAM_FUNC(menuShortcutMenuKey)(bool isTopShortcutButton) {
-  if (menuShortcutUsesValueDirection()) {
-    return isTopShortcutButton ? GEM_KEY_DOWN : GEM_KEY_UP;
-  }
-  return isTopShortcutButton ? GEM_KEY_UP : GEM_KEY_DOWN;
-}
-
-static bool RAM_FUNC(handleMenuShortcutButton)(byte buttonIndex, bool pressed) {
-  if (buttonIndex != assignCmd[0] && buttonIndex != assignCmd[1]) {
-    return false;
-  }
-  if (!menuShortcutButtonsEnabled()) {
-    return false;
-  }
-
-  if (pressed) {
-    dismissPlayedNotesOverlayForMenuInput();
-    byte keyCode = menuShortcutMenuKey(buttonIndex == assignCmd[0]);
-    if (virtualListMenuIsActive()) {
-      handleVirtualListMenuKey(keyCode);
-    } else {
-      menu.registerKeyPress(keyCode);
-    }
-    noteOverlayDirty = true;
-    screenTime = 0;
-  }
-  return true;
-}
+byte lastVelocityWheelGestureMask = 0;
+byte lastModulationWheelGestureMask = 0;
+byte lastPitchBendWheelGestureMask = 0;
 
 void RAM_FUNC(readHexes)() {
 
@@ -126,9 +88,6 @@ void RAM_FUNC(readHexes)() {
   for (byte i = 0; i < BTN_COUNT; i++) {  // For all buttons in the deck
     switch (h[i].btnState) {
       case BTN_STATE_NEWPRESS:  // just pressed
-        if (handleMenuShortcutButton(i, true)) {
-          break;
-        }
         if (delegatedControl) {
           delegatedButtonEvent(i, true);
         } else if (h[i].isCmd) {
@@ -141,9 +100,6 @@ void RAM_FUNC(readHexes)() {
         }
         break;
       case BTN_STATE_RELEASED:  // just released
-        if (handleMenuShortcutButton(i, false)) {
-          break;
-        }
         if (delegatedControl) {
           delegatedButtonEvent(i, false);
         } else if (h[i].isCmd) {
@@ -162,45 +118,104 @@ void RAM_FUNC(readHexes)() {
     }
   }
 }
+
+static void RAM_FUNC(notifyCommandWheelValue)(CommandWheelOverlayType type,
+                                              const wheelDef& wheel,
+                                              bool immediateRedraw) {
+  notifyCommandWheelOverlay(type,
+                            wheel.curValue,
+                            wheel.minValue,
+                            wheel.maxValue,
+                            immediateRedraw);
+}
+
+static byte RAM_FUNC(commandWheelGestureMask)(const wheelDef& wheel) {
+  if (*wheel.alternateMode && (*wheel.midBtn >> 1)) {
+    byte mask = 0;
+    if (*wheel.topBtn == BTN_STATE_NEWPRESS) {
+      mask |= 0b100;
+    }
+    if (*wheel.botBtn == BTN_STATE_NEWPRESS) {
+      mask |= 0b001;
+    }
+    return mask;
+  }
+
+  byte mask = 0;
+  if (*wheel.topBtn >> 1) {
+    mask |= 0b100;
+  }
+  if (*wheel.midBtn >> 1) {
+    mask |= 0b010;
+  }
+  if (*wheel.botBtn >> 1) {
+    mask |= 0b001;
+  }
+  return mask;
+}
+
+static void RAM_FUNC(notifyCommandWheelGesture)(CommandWheelOverlayType type,
+                                                const wheelDef& wheel,
+                                                int16_t previousTarget,
+                                                byte& lastGestureMask) {
+  byte gestureMask = commandWheelGestureMask(wheel);
+  bool targetChanged = wheel.targetValue != previousTarget;
+  bool newGesture = gestureMask != 0 && gestureMask != lastGestureMask;
+
+  if (targetChanged || newGesture) {
+    notifyCommandWheelValue(type, wheel, newGesture);
+  }
+
+  lastGestureMask = gestureMask;
+}
+
 void RAM_FUNC(updateWheels)() {
   if (delegatedControl) {
     return;
   }
 
-  bool menuShortcutButtonsActive = menuShortcutButtonsEnabled();
-  byte savedMenuShortcutTopState = h[assignCmd[0]].btnState;
-  byte savedMenuShortcutMidState = h[assignCmd[1]].btnState;
-  byte savedMenuShortcutModifierState = h[assignCmd[6]].btnState;
-  if (menuShortcutButtonsActive) {
-    h[assignCmd[0]].btnState = BTN_STATE_OFF;
-    h[assignCmd[1]].btnState = BTN_STATE_OFF;
-    h[assignCmd[6]].btnState = BTN_STATE_OFF;
-  }
-
+  int16_t previousVelocityTarget = velWheel.targetValue;
   velWheel.setTargetValue();
+  notifyCommandWheelGesture(CommandWheelOverlayType::Velocity,
+                            velWheel,
+                            previousVelocityTarget,
+                            lastVelocityWheelGestureMask);
   bool upd = velWheel.updateValue(runTime);
   if (upd) {
     sendToLog("vel became " + std::to_string(velWheel.curValue));
+    if (commandWheelOverlayActive()) {
+      notifyCommandWheelValue(CommandWheelOverlayType::Velocity, velWheel, false);
+    }
   }
   if (toggleWheel) {
+    int16_t previousPitchBendTarget = pbWheel.targetValue;
     pbWheel.setTargetValue();
+    notifyCommandWheelGesture(CommandWheelOverlayType::PitchBend,
+                              pbWheel,
+                              previousPitchBendTarget,
+                              lastPitchBendWheelGestureMask);
     upd = pbWheel.updateValue(runTime);
     if (upd) {
+      if (commandWheelOverlayActive()) {
+        notifyCommandWheelValue(CommandWheelOverlayType::PitchBend, pbWheel, false);
+      }
       sendMIDIpitchBendToCh1();
       updateSynthWithNewFreqs();
     }
   } else {
+    int16_t previousModulationTarget = modWheel.targetValue;
     modWheel.setTargetValue();
+    notifyCommandWheelGesture(CommandWheelOverlayType::Modulation,
+                              modWheel,
+                              previousModulationTarget,
+                              lastModulationWheelGestureMask);
     upd = modWheel.updateValue(runTime);
     if (upd) {
+      if (commandWheelOverlayActive()) {
+        notifyCommandWheelValue(CommandWheelOverlayType::Modulation, modWheel, false);
+      }
       sendMIDImodulationToCh1();
     }
-  }
-
-  if (menuShortcutButtonsActive) {
-    h[assignCmd[0]].btnState = savedMenuShortcutTopState;
-    h[assignCmd[1]].btnState = savedMenuShortcutMidState;
-    h[assignCmd[6]].btnState = savedMenuShortcutModifierState;
   }
 }
 void setupRotary() {
@@ -313,6 +328,7 @@ void dealWithRotary() {
 
   if (virtualListMenuIsActive()) {
     if (justReleased && !rotaryPanicSuppressClick) {
+      dismissCommandWheelOverlay();
       dismissPlayedNotesOverlayForMenuInput();
       handleVirtualListMenuKey(GEM_KEY_OK);
       noteOverlayDirty = true;
@@ -320,6 +336,7 @@ void dealWithRotary() {
     }
     if (storeRotaryTurn != 0) {
       bool turnIsClockwise = (storeRotaryTurn == 8);
+      dismissCommandWheelOverlay();
       dismissPlayedNotesOverlayForMenuInput();
       byte keyCode = rotaryInvert
                        ? (turnIsClockwise ? GEM_KEY_DOWN : GEM_KEY_UP)
@@ -331,6 +348,7 @@ void dealWithRotary() {
     }
   } else if (menu.readyForKey()) {
     if (justReleased && !rotaryPanicSuppressClick) {
+      dismissCommandWheelOverlay();
       dismissPlayedNotesOverlayForMenuInput();
       if (!handleVirtualListLauncherKey(GEM_KEY_OK)) {
         menu.registerKeyPress(GEM_KEY_OK);
@@ -340,6 +358,7 @@ void dealWithRotary() {
     }
     if (storeRotaryTurn != 0) {
       bool turnIsClockwise = (storeRotaryTurn == 8);
+      dismissCommandWheelOverlay();
       dismissPlayedNotesOverlayForMenuInput();
       byte keyCode = rotaryInvert
                        ? (turnIsClockwise ? GEM_KEY_DOWN : GEM_KEY_UP)

--- a/src/firmware/menu/CommandWheelOverlay.cpp
+++ b/src/firmware/menu/CommandWheelOverlay.cpp
@@ -1,0 +1,240 @@
+#include "CommandWheelOverlay.h"
+
+#include "../app/DiagnosticsTiming.h"
+#include "../sequencer/SequencerMode.h"
+#include "MenuAndDisplay.h"
+
+extern bool screenSaverOn;
+
+namespace {
+
+constexpr uint64_t kOverlayHoldMicros = 3000000ULL;
+constexpr uint64_t kOverlayRedrawIntervalMicros = 100000ULL;
+constexpr int kMeterX = 10;
+constexpr int kMeterY = 94;
+constexpr int kMeterWidth = 108;
+constexpr int kMeterHeight = 14;
+constexpr int kMeterInnerX = kMeterX + 2;
+constexpr int kMeterInnerY = kMeterY + 2;
+constexpr int kMeterInnerWidth = kMeterWidth - 4;
+constexpr int kMeterInnerHeight = kMeterHeight - 4;
+
+bool overlayActive = false;
+bool overlayVisible = false;
+bool overlayDirty = false;
+bool overlayRedrawPending = false;
+CommandWheelOverlayType overlayType = CommandWheelOverlayType::Velocity;
+int16_t overlayCurrentValue = 0;
+int16_t overlayMinValue = 0;
+int16_t overlayMaxValue = 127;
+uint64_t overlayExpiresAt = 0;
+uint64_t overlayNextRedrawAt = 0;
+
+const char* overlayTitle(CommandWheelOverlayType type) {
+  switch (type) {
+    case CommandWheelOverlayType::Velocity:
+      return "VELOCITY";
+    case CommandWheelOverlayType::Modulation:
+      return "MOD WHEEL";
+    case CommandWheelOverlayType::PitchBend:
+      return "PITCH BEND";
+  }
+  return "";
+}
+
+int valueSpan() {
+  int span = static_cast<int>(overlayMaxValue) - static_cast<int>(overlayMinValue);
+  return span > 0 ? span : 1;
+}
+
+int valueToMeterWidth(int16_t value) {
+  long clamped = std::max(static_cast<long>(overlayMinValue),
+                          std::min(static_cast<long>(overlayMaxValue), static_cast<long>(value)));
+  long offset = clamped - overlayMinValue;
+  return static_cast<int>((offset * kMeterInnerWidth + (valueSpan() / 2)) / valueSpan());
+}
+
+int pitchBendPercent(int16_t value) {
+  if (value == 0) {
+    return 0;
+  }
+  long rawValue = static_cast<long>(value);
+  long magnitude = rawValue < 0 ? -rawValue : rawValue;
+  magnitude = std::min(magnitude, 8192L);
+  long denominator = value < 0 ? 8192L : 8191L;
+  long percent = (magnitude * 100L + (denominator / 2L)) / denominator;
+  if (percent > 100L) {
+    percent = 100L;
+  }
+  return value < 0 ? -static_cast<int>(percent) : static_cast<int>(percent);
+}
+
+void formatValue(CommandWheelOverlayType type, int16_t value, char* out, size_t outSize) {
+  if (out == nullptr || outSize == 0) {
+    return;
+  }
+  if (type == CommandWheelOverlayType::PitchBend) {
+    int percent = pitchBendPercent(value);
+    if (percent > 0) {
+      snprintf(out, outSize, "+%d%%", percent);
+    } else {
+      snprintf(out, outSize, "%d%%", percent);
+    }
+    return;
+  }
+  snprintf(out, outSize, "%d", static_cast<int>(value));
+}
+
+void drawCenteredText(const char* text, int y) {
+  int width = u8g2.getStrWidth(text);
+  int x = (u8g2.getDisplayWidth() - width) / 2;
+  if (x < 0) {
+    x = 0;
+  }
+  u8g2.drawStr(x, y, text);
+}
+
+void drawStandardMeter() {
+  u8g2.drawFrame(kMeterX, kMeterY, kMeterWidth, kMeterHeight);
+  int width = valueToMeterWidth(overlayCurrentValue);
+  if (width > 0) {
+    u8g2.drawBox(kMeterInnerX, kMeterInnerY, width, kMeterInnerHeight);
+  }
+}
+
+void drawCenteredMeter() {
+  u8g2.setDrawColor(1);
+  u8g2.drawFrame(kMeterX, kMeterY, kMeterWidth, kMeterHeight);
+  const int leftBound = kMeterInnerX;
+  const int rightBound = kMeterInnerX + kMeterInnerWidth - 1;
+  const int centerX = kMeterInnerX + (kMeterInnerWidth / 2);
+  int percent = pitchBendPercent(overlayCurrentValue);
+
+  if (percent > 0) {
+    const int rightSpan = rightBound - centerX;
+    int rightEdge = centerX + ((percent * rightSpan + 50) / 100);
+    rightEdge = std::max(centerX + 1, std::min(rightBound, rightEdge));
+    u8g2.drawBox(centerX + 1, kMeterInnerY, rightEdge - centerX, kMeterInnerHeight);
+  } else if (percent < 0) {
+    const int leftSpan = centerX - leftBound;
+    int leftEdge = centerX - (((-percent) * leftSpan + 50) / 100);
+    leftEdge = std::max(leftBound, std::min(centerX - 1, leftEdge));
+    u8g2.drawBox(leftEdge, kMeterInnerY, centerX - leftEdge, kMeterInnerHeight);
+  }
+
+  u8g2.drawVLine(centerX, kMeterInnerY - 2, kMeterInnerHeight + 4);
+}
+
+void restoreUnderlyingDisplay() {
+  if (sequencerModeActive()) {
+    restoreSequencerDisplayAfterPlayedNotesOverlay();
+  } else {
+    restoreInteractiveMenuDisplay();
+  }
+}
+
+void RAM_FUNC(clearOverlayState)() {
+  overlayActive = false;
+  overlayVisible = false;
+  overlayDirty = false;
+  overlayRedrawPending = false;
+  overlayExpiresAt = 0;
+  overlayNextRedrawAt = 0;
+}
+
+}  // namespace
+
+bool commandWheelOverlayActive() {
+  return overlayActive || overlayVisible;
+}
+
+void RAM_FUNC(notifyCommandWheelOverlay)(CommandWheelOverlayType type,
+                                         int16_t currentValue,
+                                         int16_t minValue,
+                                         int16_t maxValue,
+                                         bool immediateRedraw) {
+  bool newlyShown = !overlayActive || overlayType != type;
+  overlayCurrentValue = currentValue;
+  overlayType = type;
+  overlayMinValue = minValue;
+  overlayMaxValue = maxValue;
+  overlayActive = true;
+  if (immediateRedraw || newlyShown || runTime >= overlayNextRedrawAt) {
+    overlayDirty = true;
+    overlayRedrawPending = false;
+    overlayNextRedrawAt = runTime + kOverlayRedrawIntervalMicros;
+  } else {
+    overlayRedrawPending = true;
+  }
+  overlayExpiresAt = runTime + kOverlayHoldMicros;
+  screenTime = 0;
+}
+
+void RAM_FUNC(dismissCommandWheelOverlay)() {
+  clearOverlayState();
+}
+
+void drawCommandWheelOverlay() {
+  if (!overlayActive) {
+    return;
+  }
+
+  if (runTime > overlayExpiresAt) {
+    bool wasVisible = overlayVisible;
+    clearOverlayState();
+    if (wasVisible) {
+      restoreUnderlyingDisplay();
+    }
+    return;
+  }
+
+  if (!overlayDirty && overlayRedrawPending && runTime >= overlayNextRedrawAt) {
+    overlayDirty = true;
+    overlayRedrawPending = false;
+    overlayNextRedrawAt = runTime + kOverlayRedrawIntervalMicros;
+  }
+
+  if (!overlayDirty && overlayVisible) {
+    return;
+  }
+
+  if (screenSaverOn) {
+    screenSaverOn = false;
+    u8g2.setContrast(CONTRAST_AWAKE);
+  }
+
+  char valueLabel[10];
+  formatValue(overlayType, overlayCurrentValue, valueLabel, sizeof(valueLabel));
+
+  u8g2.clearBuffer();
+  u8g2.setDrawColor(1);
+  u8g2.setFont(u8g2_font_7x14_tf);
+  drawCenteredText(overlayTitle(overlayType), 14);
+  u8g2.drawHLine(12, 34, 104);
+
+  u8g2.setFont(u8g2_font_logisoso16_tf);
+  if (u8g2.getStrWidth(valueLabel) > 124) {
+    u8g2.setFont(u8g2_font_7x14_tf);
+  }
+  drawCenteredText(valueLabel, 46);
+
+  u8g2.setFont(u8g2_font_6x13_tf);
+  if (overlayType == CommandWheelOverlayType::PitchBend) {
+    drawCenteredText("-100%   0   +100%", 78);
+    drawCenteredMeter();
+  } else {
+    char rangeLabel[18];
+    snprintf(rangeLabel,
+             sizeof(rangeLabel),
+             "%d..%d",
+             static_cast<int>(overlayMinValue),
+             static_cast<int>(overlayMaxValue));
+    drawCenteredText(rangeLabel, 78);
+    drawStandardMeter();
+  }
+
+  overlayVisible = true;
+  overlayDirty = false;
+  u8g2.setDrawColor(1);
+  u8g2.sendBuffer();
+}

--- a/src/firmware/menu/CommandWheelOverlay.h
+++ b/src/firmware/menu/CommandWheelOverlay.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "../FirmwareModule.h"
+
+enum class CommandWheelOverlayType : byte {
+  Velocity,
+  Modulation,
+  PitchBend
+};
+
+bool commandWheelOverlayActive();
+void RAM_FUNC(notifyCommandWheelOverlay)(CommandWheelOverlayType type,
+                                         int16_t currentValue,
+                                         int16_t minValue,
+                                         int16_t maxValue,
+                                         bool immediateRedraw);
+void RAM_FUNC(dismissCommandWheelOverlay)();
+void drawCommandWheelOverlay();

--- a/src/firmware/menu/GeometryMenu.cpp
+++ b/src/firmware/menu/GeometryMenu.cpp
@@ -1,4 +1,5 @@
 #include "../FirmwareModule.h"
+#include "CommandWheelOverlay.h"
 #include "GeometryMenu.h"
 #include "MenuFolderUtils.h"
 #include "MenuAndDisplay.h"
@@ -580,6 +581,7 @@ void serviceUserGeometryMenuRebuild() {
     rebuildUserGeometryVirtualList(userGeometryVirtualKind);
     redrawVirtualListMenu();
   } else if (menu.getCurrentMenuPage() == &menuPageMain) {
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }

--- a/src/firmware/menu/MenuAndDisplay.cpp
+++ b/src/firmware/menu/MenuAndDisplay.cpp
@@ -18,6 +18,7 @@
 #include "../sequencer/SequencerMode.h"
 #include "../sequencer/SequencerPlaybackSettings.h"
 #include "../synth/SynthAudio.h"
+#include "CommandWheelOverlay.h"
 #include "GeometryMenu.h"
 #include "MenuAndDisplay.h"
 #include "PlayedNotesOverlay.h"
@@ -100,6 +101,7 @@ void drawDelegatedControlScreen() {
     return;
   }
 
+  dismissCommandWheelOverlay();
   noteOverlayVisible = false;
   noteBadgeVisible = false;
   noteOverlayTemporaryWake = false;
@@ -118,6 +120,7 @@ void drawDelegatedControlScreen() {
 }
 
 void restoreInteractiveMenuDisplay() {
+  dismissCommandWheelOverlay();
   if (virtualListMenuIsActive()) {
     redrawVirtualListMenu();
   } else {
@@ -136,6 +139,7 @@ void restoreMenuAfterDelegatedControl() {
 }
 
 void drawPresetSyncTransferScreen() {
+  dismissCommandWheelOverlay();
   if (!presetSyncTransferScreenVisible) {
     presetSyncTransferScreenWokeDisplayFromSleep = screenSaverOn;
     presetSyncTransferSavedScreenTime = screenTime;
@@ -187,6 +191,7 @@ void closePresetSyncTransferScreen() {
 }
 
 void showFlashSaveScreen() {
+  dismissCommandWheelOverlay();
   if (!flashSaveScreenVisible) {
     flashSaveScreenWokeDisplayFromSleep = screenSaverOn;
     flashSaveSavedScreenTime = screenTime;
@@ -575,6 +580,7 @@ void serialDebugRuntimeChanged(GEMCallbackData /*callbackData*/) {
   }
   updateSerialDebugRuntime();
   updateSerialDebugMenuVisibility();
+  dismissCommandWheelOverlay();
   menu.drawMenu();
 }
 
@@ -2542,6 +2548,7 @@ void serviceVirtualListLauncherLabelScroll() {
       || delegatedControl
       || presetSyncTransferActive
       || flashSaveScreenVisible
+      || commandWheelOverlayActive()
       || noteBadgeVisible
       || noteOverlayVisible
       || screenSaverOn) {
@@ -2625,6 +2632,7 @@ void menuHome() {
   resetVirtualListLauncherScrollTracking(false);
   restoreVirtualListLauncherLabels();
   menu.setMenuPageCurrent(menuPageMain);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
 }
 
@@ -2633,6 +2641,7 @@ void menuSynthOptionsHome() {
   resetVirtualListLauncherScrollTracking(false);
   restoreVirtualListLauncherLabels();
   menu.setMenuPageCurrent(menuPageSynth);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
 }
 
@@ -2684,6 +2693,7 @@ void addPreviewMenuItem(GEMPage& page, GEMItem& item, void (*previewCallback)(GE
 
 void rebootToBootloader() {
   menu.setMenuPageCurrent(menuPageReboot);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
   clearLEDs();
   rp2040.rebootToBootloader();
@@ -3014,6 +3024,7 @@ void screenSaver() {
     }
   } else {
     if (!screenSaverOn) {
+      dismissCommandWheelOverlay();
       screenSaverOn = 1;
       u8g2.setContrast(CONTRAST_SCREENSAVER);
       u8g2.clear();

--- a/src/firmware/menu/PlayedNotesOverlay.cpp
+++ b/src/firmware/menu/PlayedNotesOverlay.cpp
@@ -1,5 +1,6 @@
 #include "../FirmwareModule.h"
 #include "PlayedNotesOverlay.h"
+#include "CommandWheelOverlay.h"
 #include "MenuAndDisplay.h"
 #include "../app/DiagnosticsTiming.h"
 #include "../app/PlatformCommon.h"
@@ -425,6 +426,7 @@ void drawCompactPlayedNoteBadgeFrame(const char* noteText) {
     return;
   }
 
+  dismissCommandWheelOverlay();
   int badgeX = u8g2.getDisplayWidth() - PLAYED_NOTE_BADGE_WIDTH;
   if (badgeX < 0) {
     badgeX = 0;
@@ -493,6 +495,7 @@ void drawCompactPlayedNoteBadge(PlayedNoteDisplaySource source) {
   noteOverlayVisible = false;
   noteOverlayDirty = false;
 
+  dismissCommandWheelOverlay();
   drawCompactPlayedNoteBadgeFrame(noteBadgeText);
   u8g2.sendBuffer();
 }
@@ -597,6 +600,7 @@ void drawPlayedNotesOverlay() {
   noteBadgeText[0] = '\0';
   noteOverlayDirty = false;
 
+  dismissCommandWheelOverlay();
   u8g2.clearBuffer();
   u8g2.setFont(u8g2_font_6x13_tf);
   u8g2.drawStr(8, 16, "Now Playing");

--- a/src/firmware/menu/SynthPresetMenu.cpp
+++ b/src/firmware/menu/SynthPresetMenu.cpp
@@ -1,4 +1,5 @@
 #include "../FirmwareModule.h"
+#include "CommandWheelOverlay.h"
 #include "MenuFolderUtils.h"
 #include "MenuAndDisplay.h"
 #include "SynthPresetMenu.h"
@@ -376,6 +377,7 @@ void serviceSynthPresetMenuRebuild() {
   synthPresetMenuRebuildPending = false;
   rebuildSynthPresetMenuItems();
   if (menu.getCurrentMenuPage() == &menuPageSynth) {
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }

--- a/src/firmware/menu/SynthWavetableMenu.cpp
+++ b/src/firmware/menu/SynthWavetableMenu.cpp
@@ -1,4 +1,5 @@
 #include "../FirmwareModule.h"
+#include "CommandWheelOverlay.h"
 #include "MenuFolderUtils.h"
 #include "MenuAndDisplay.h"
 #include "SynthPresetMenu.h"
@@ -378,6 +379,7 @@ void serviceSynthWavetableMenuRebuild() {
   synthWavetableMenuRebuildPending = false;
   rebuildSynthWavetableMenuItems();
   if (menu.getCurrentMenuPage() == &menuPageSynth) {
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }

--- a/src/firmware/menu/VirtualListMenu.cpp
+++ b/src/firmware/menu/VirtualListMenu.cpp
@@ -1,4 +1,5 @@
 #include "../FirmwareModule.h"
+#include "CommandWheelOverlay.h"
 #include "MenuAndDisplay.h"
 #include "PlayedNotesOverlay.h"
 #include "VirtualListMenu.h"
@@ -302,6 +303,7 @@ void redrawVirtualListMenu() {
   if (!active) {
     return;
   }
+  dismissCommandWheelOverlay();
   uint16_t totalItems = virtualItemCount();
   if (totalItems > 0 && currentItemIndex >= totalItems) {
     currentItemIndex = static_cast<uint16_t>(totalItems - 1);

--- a/src/firmware/sequencer/SequencerFileMenu.cpp
+++ b/src/firmware/sequencer/SequencerFileMenu.cpp
@@ -10,6 +10,7 @@
 #include "../app/DiagnosticsTiming.h"
 #include "../app/RuntimeDefaults.h"
 #include "../hardware/LedRender.h"
+#include "../menu/CommandWheelOverlay.h"
 #include "../menu/MenuAndDisplay.h"
 #include "../menu/PlayedNotesOverlay.h"
 #include "../menu/VirtualListMenu.h"
@@ -678,6 +679,7 @@ void returnToSequencerMenu() {
   invalidateBrowserCache();
   if (g_sequencerPage != nullptr) {
     menu.setMenuPageCurrent(*g_sequencerPage);
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }
@@ -1129,6 +1131,7 @@ void refreshUsbBackupMenu(bool redrawMenu) {
   usbBackupStatusTwoItem().setTitle(g_usbBackupStatusLineTwo);
 
   if (redrawMenu && g_usbBackupPage != nullptr && menu.getCurrentMenuPage() == g_usbBackupPage) {
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }
@@ -1163,6 +1166,7 @@ void stopUsbBackupCallback() {
     return;
   }
   menu.setMenuPageCurrent(*g_usbBackupStopPage);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
   g_lastMenuPage = g_usbBackupStopPage;
 }
@@ -1174,6 +1178,7 @@ void confirmUsbBackupExitCallback() {
   }
   if (g_sequencerPage != nullptr) {
     menu.setMenuPageCurrent(fileMenuPage(*g_sequencerPage));
+    dismissCommandWheelOverlay();
     menu.drawMenu();
     g_lastMenuPage = &fileMenuPage(*g_sequencerPage);
   }
@@ -1186,6 +1191,7 @@ void cancelUsbBackupExitCallback() {
   }
   menu.setMenuPageCurrent(*g_usbBackupPage);
   refreshUsbBackupMenu(false);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
   showStatusToast("USB Backup", "Session active");
   g_lastMenuPage = g_usbBackupPage;
@@ -1198,6 +1204,7 @@ void confirmUsbBackupStopCallback() {
   }
   menu.setMenuPageCurrent(*g_usbBackupPage);
   refreshUsbBackupMenu(false);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
   showStatusToast("USB Backup", "Session closed");
   g_lastMenuPage = g_usbBackupPage;
@@ -1209,6 +1216,7 @@ void cancelUsbBackupStopCallback() {
   }
   menu.setMenuPageCurrent(*g_usbBackupPage);
   refreshUsbBackupMenu(false);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
   showStatusToast("USB Backup", "Session active");
   g_lastMenuPage = g_usbBackupPage;
@@ -1228,6 +1236,7 @@ void guardUsbBackupMenuExit() {
       currentPage != g_usbBackupStopPage &&
       isUsbBackupActive()) {
     menu.setMenuPageCurrent(*g_usbBackupExitPage);
+    dismissCommandWheelOverlay();
     menu.drawMenu();
     g_lastMenuPage = g_usbBackupExitPage;
     return;
@@ -1259,6 +1268,7 @@ void openActionPage() {
   g_fileUiActive = true;
   menu.setMenuPageCurrent(actionPage());
   actionPage().setCurrentMenuItemIndex(4);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
 }
 
@@ -1306,6 +1316,7 @@ void actionDeleteCallback() {
   deletePage().setTitle(g_deleteTargetIsFolder ? "Delete Folder?" : "Delete File?");
   menu.setMenuPageCurrent(deletePage());
   deletePage().setCurrentMenuItemIndex(4);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
 }
 
@@ -1665,6 +1676,7 @@ void drawFileMenuOverlay() {
     return;
   }
 
+  dismissCommandWheelOverlay();
   screenTime = 0;
   if (screenSaverOn) {
     screenSaverOn = false;

--- a/src/firmware/sequencer/SequencerLightMenu.cpp
+++ b/src/firmware/sequencer/SequencerLightMenu.cpp
@@ -4,6 +4,7 @@
 
 #if HEXBOARD_ENABLE_SEQUENCER
 #include "SequencerLightSettings.h"
+#include "../menu/CommandWheelOverlay.h"
 #include "../menu/MenuAndDisplay.h"
 
 namespace sequencer {
@@ -93,6 +94,7 @@ GEMItem& stepHueItem() {
 void refreshLightSettingsMenu(bool redrawMenu) {
   stepHueItem().hide(stepColorMode() != kStepColorRegular);
   if (redrawMenu && menu.getCurrentMenuPage() == &lightSettingsPage(menuPageMain)) {
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }

--- a/src/firmware/sequencer/SequencerMode.cpp
+++ b/src/firmware/sequencer/SequencerMode.cpp
@@ -15,6 +15,7 @@
 #include "SequencerTools.h"
 #include "SequencerTransport.h"
 #include "SequencerUsbBackup.h"
+#include "../menu/CommandWheelOverlay.h"
 #include "../menu/MenuAndDisplay.h"
 #include "../synth/SynthAudio.h"
 
@@ -76,6 +77,7 @@ void refreshSequencerTitleRow(bool redrawIfVisible = false) {
     if (sequencerDisplayOverlayActive()) {
       sequencer::markOverlayDirty();
     } else {
+      dismissCommandWheelOverlay();
       menu.drawMenu();
     }
   }
@@ -121,6 +123,7 @@ void enterSequencerMode() {
   screenTime = 0;
   menu.setMenuPageCurrent(sequencerMenuPage());
   refreshSequencerTitleRow(false);
+  dismissCommandWheelOverlay();
   menu.drawMenu();
 #endif
 }

--- a/src/firmware/sequencer/SequencerOverlay.cpp
+++ b/src/firmware/sequencer/SequencerOverlay.cpp
@@ -8,6 +8,7 @@
 #include "SequencerTools.h"
 #include "../app/DiagnosticsTiming.h"
 #include "../app/PlatformCommon.h"
+#include "../menu/CommandWheelOverlay.h"
 #include "../menu/MenuAndDisplay.h"
 #include "../model/ScalePalettePreset.h"
 #include "../tuning/Tuning.h"
@@ -189,6 +190,7 @@ byte countOverviewStepsThatFit(byte firstStep) {
 }
 
 void keepOverlayDisplayAwake() {
+  dismissCommandWheelOverlay();
   screenTime = 0;
   if (::screenSaverOn) {
     ::screenSaverOn = false;
@@ -301,6 +303,7 @@ bool sequencerIdleDisplayBlanked() {
 }
 
 void redrawSequencerIdleBlankDisplay() {
+  dismissCommandWheelOverlay();
   overlayVisible = false;
   overlayVisibleWasStatus = false;
   overlayDirty = false;
@@ -377,6 +380,7 @@ void hideOverview() {
   overlayDirty = true;
   if (!hasSelectedStep() && toolMode() == SequencerToolMode::Normal) {
     idleDisplayBlanked = false;
+    dismissCommandWheelOverlay();
     menu.drawMenu();
   }
 }


### PR DESCRIPTION
Adds a transient OLED overlay for velocity, modulation, and pitch-bend command-button changes, including live held-button updates and pitch-bend percentage/meter display.

Also removes command-button menu navigation so the command buttons stay dedicated to live wheel controls otherwise they were fighting in a way that didn't seem possible to easily resolve.